### PR TITLE
Add keepValueAfterSubmit option

### DIFF
--- a/packages/core/client/src/index.ts
+++ b/packages/core/client/src/index.ts
@@ -29,6 +29,7 @@ export * from './appInfo';
 export * from './application';
 export * from './async-data-provider';
 export * from './block-provider';
+export { resetFormCorrectly } from './block-provider/hooks';
 export * from './collection-manager';
 
 export * from './common';

--- a/packages/core/client/src/locale/en-US.json
+++ b/packages/core/client/src/locale/en-US.json
@@ -550,6 +550,7 @@
   "Original title: ": "Original title: ",
   "Delete table column": "Delete table column",
   "Skip required validation": "Skip required validation",
+  "Keep value after submit": "Keep value after submit",
   "Form values": "Form values",
   "Fields values": "Fields values",
   "The field has been deleted": "The field has been deleted",

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -577,6 +577,7 @@
   "Original title: ": "原始标题: ",
   "Delete table column": "删除列",
   "Skip required validation": "跳过必填校验",
+  "Keep value after submit": "保持原值",
   "Form values": "表单值",
   "Fields values": "字段值",
   "The field has been deleted": "字段已删除",

--- a/packages/core/client/src/schema-component/antd/form/Form.tsx
+++ b/packages/core/client/src/schema-component/antd/form/Form.tsx
@@ -106,9 +106,16 @@ export const Form: React.FC<FormProps> & { Designer?: any } = observer(
       {
         uid: fieldSchema['x-uid'],
         async onSuccess(data) {
+          const keepValues: Record<string, any> = {};
+          Object.keys(form.fields).forEach((key) => {
+            const field = form.fields[key] as any;
+            if (field?.componentProps?.keepValueAfterSubmit) {
+              keepValues[key] = field.value;
+            }
+          });
           await form.reset();
-          form.setValues(data?.data);
-          form.setInitialValues(data?.data);
+          form.setValues({ ...data?.data, ...keepValues });
+          form.setInitialValues({ ...data?.data, ...keepValues });
         },
       },
       props,

--- a/packages/core/client/src/schema-items/GeneralSchemaItems.tsx
+++ b/packages/core/client/src/schema-items/GeneralSchemaItems.tsx
@@ -171,6 +171,29 @@ export const GeneralSchemaItems: React.FC<{
             }}
           />
         )}
+        {!field.readPretty && (
+          <SchemaSettingsSwitchItem
+            key="keep-value-after-submit"
+            title={t('Keep value after submit')}
+            checked={fieldSchema['x-component-props']?.keepValueAfterSubmit}
+            onChange={(checked) => {
+              field.componentProps = field.componentProps || {};
+              field.componentProps.keepValueAfterSubmit = checked;
+              fieldSchema['x-component-props'] = fieldSchema['x-component-props'] || {};
+              fieldSchema['x-component-props'].keepValueAfterSubmit = checked;
+              dn.emit('patch', {
+                schema: {
+                  'x-uid': fieldSchema['x-uid'],
+                  'x-component-props': {
+                    ...fieldSchema['x-component-props'],
+                    keepValueAfterSubmit: checked,
+                  },
+                },
+              });
+              dn.refresh();
+            }}
+          />
+        )}
       </>
     );
   },

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/hooks/usePublicSubmitActionProps.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/hooks/usePublicSubmitActionProps.ts
@@ -8,7 +8,7 @@
  */
 import { useContext } from 'react';
 import { useForm, useFieldSchema, useField } from '@formily/react';
-import { useDataBlockResource, useCollectValuesToSubmit, useFormBlockContext } from '@nocobase/client';
+import { useDataBlockResource, useCollectValuesToSubmit, useFormBlockContext, resetFormCorrectly } from '@nocobase/client';
 import { PublicFormMessageContext } from '../components/PublicFormPage';
 
 export const usePublicSubmitActionProps = () => {
@@ -38,7 +38,7 @@ export const usePublicSubmitActionProps = () => {
             : undefined,
           updateAssociationValues,
         });
-        await form.reset();
+        await resetFormCorrectly(form);
         actionField.data.loading = false;
         setShowMessage(true);
       } catch (error) {

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/hooks/useSubmitActionProps.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/hooks/useSubmitActionProps.ts
@@ -17,6 +17,7 @@ import {
   useDataBlockResource,
   usePlugin,
 } from '@nocobase/client';
+import { resetFormCorrectly } from '@nocobase/client';
 import { App as AntdApp } from 'antd';
 import PluginPublicFormsClient from '..';
 
@@ -99,7 +100,7 @@ export const useSubmitActionProps = () => {
         });
         await api.resource('uiSchemas').insert({ values: schema });
       }
-      form.reset();
+      await resetFormCorrectly(form);
       await service.refresh();
       message.success('Saved successfully!');
       setVisible(false);


### PR DESCRIPTION
## Summary
- keep field values on form reset with `resetFormCorrectly`
- merge preserved values when reloading form data
- toggle `keepValueAfterSubmit` from field settings
- expose `resetFormCorrectly` helper

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test:client` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6856614b3c2c832792429e804df6be11