### PR TITLE
Add keep value after submit plugin

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-keep-value/package.json
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@nocobase/plugin-field-keep-value",
+  "version": "1.8.5",
+  "main": "./dist/server/index.js",
+  "displayName": "Keep field value",
+  "displayName.zh-CN": "字段值保持",
+  "description": "Add switch to preserve field value after submit",
+  "description.zh-CN": "在字段属性中添加提交后保持原值的开关",
+  "license": "AGPL-3.0",
+  "homepage": "https://www.nocobase.com",
+  "devDependencies": {
+    "@ant-design/icons": "5.x",
+    "@formily/core": "2.x",
+    "@formily/react": "2.x",
+    "antd": "5.x",
+    "react": "^18.2.0",
+    "react-i18next": "^11.15.1"
+  },
+  "peerDependencies": {
+    "@nocobase/client": "1.x",
+    "@nocobase/server": "1.x",
+    "@nocobase/test": "1.x"
+  }
+}

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/client/index.tsx
@@ -1,0 +1,53 @@
+import { Plugin, SchemaSettings, useDesignable, useFieldSchema } from '@nocobase/client';
+import { Form } from '@formily/core';
+import { useTranslation } from 'react-i18next';
+
+export const keepValueFieldSettings = new SchemaSettings({
+  name: 'fieldSettings:keepValueAfterSubmit',
+  items: [
+    {
+      name: 'keepValueAfterSubmit',
+      type: 'switch',
+      useComponentProps() {
+        const { t } = useTranslation();
+        const fieldSchema = useFieldSchema();
+        const { dn } = useDesignable();
+        return {
+          title: t('Keep value after submit'),
+          checked: !!fieldSchema['x-component-props']?.keepValueAfterSubmit,
+          onChange(value: boolean) {
+            const schema = { ['x-uid']: fieldSchema['x-uid'] } as any;
+            fieldSchema['x-component-props'] = fieldSchema['x-component-props'] || {};
+            fieldSchema['x-component-props'].keepValueAfterSubmit = value;
+            schema['x-component-props'] = fieldSchema['x-component-props'];
+            dn.emit('patch', { schema });
+            dn.refresh();
+          },
+        };
+      },
+    },
+  ],
+});
+
+export class PluginFieldKeepValueClient extends Plugin {
+  async load() {
+    this.app.schemaSettingsManager.add(keepValueFieldSettings);
+
+    const oldReset = Form.prototype.reset;
+    Form.prototype.reset = async function (...args: any[]) {
+      const keepList: { field: any; value: any }[] = [];
+      Object.values(this.fields).forEach((f: any) => {
+        if (f.componentProps?.keepValueAfterSubmit) {
+          keepList.push({ field: f, value: f.value });
+        }
+      });
+      await oldReset.apply(this, args as any);
+      keepList.forEach(({ field, value }) => {
+        field.setValue(value);
+        field.setInitialValue(value);
+      });
+    };
+  }
+}
+
+export default PluginFieldKeepValueClient;

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/index.ts
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/index.ts
@@ -1,0 +1,2 @@
+export * from './server';
+export { default } from './server';

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/locale/en-US.json
@@ -1,0 +1,3 @@
+{
+  "Keep value after submit": "Keep value after submit"
+}

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/locale/zh-CN.json
@@ -1,0 +1,3 @@
+{
+  "Keep value after submit": "提交后保持原值"
+}

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/server/index.ts
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/server/index.ts
@@ -1,0 +1,9 @@
+import { Plugin } from '@nocobase/server';
+
+export class PluginFieldKeepValueServer extends Plugin {
+  async load() {
+    // Server side hook not required
+  }
+}
+
+export default PluginFieldKeepValueServer;


### PR DESCRIPTION
## Summary
- add `plugin-field-keep-value` package
- allow users to enable `Keep value after submit` on form fields
- patch form reset so fields with the option retain their values

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6877b931a1088327a18ddd04635adc83