### PR TITLE
Add field value retention plugin

### DIFF
--- a/packages/core/client/src/block-provider/hooks/index.ts
+++ b/packages/core/client/src/block-provider/hooks/index.ts
@@ -1739,11 +1739,18 @@ function getTargetField(obj) {
  * @param form
  */
 async function resetFormCorrectly(form: Form) {
+  const oldValues = { ...form.values };
   untracked(() => {
     Object.keys(form.fields).forEach((key) => {
-      if (isSubMode(form.fields[key])) {
+      const field = form.fields[key] as Field;
+      if (isSubMode(field)) {
         // 清空子表格或者子表单的初始值，可以确保后面的 reset 会清空子表格或者子表单的值
-        (form.fields[key] as Field).initialValue = null;
+        field.initialValue = null;
+        return;
+      }
+
+      if ((field.componentProps as any)?.retainValue) {
+        field.initialValue = oldValues[key];
       }
     });
   });

--- a/packages/plugins/@nocobase/plugin-field-keep-value/package.json
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@nocobase/plugin-field-keep-value",
+  "version": "1.0.0",
+  "main": "./dist/server/index.js",
+  "types": "./dist/server/index.d.ts",
+  "license": "AGPL-3.0",
+  "peerDependencies": {
+    "@nocobase/client": "1.x",
+    "@nocobase/server": "1.x"
+  }
+}

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/client/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 export class PluginFieldKeepValueClient extends Plugin {
   async load() {
-    this.schemaSettingsManager.addItem('fieldSettings:FormItem.decoratorOptions', 'keepValueAfterSubmit', {
+    this.app.schemaSettingsManager.addItem('fieldSettings:FormItem', 'decoratorOptions.keepValueAfterSubmit', {
       type: 'switch',
       useComponentProps() {
         const { t } = useTranslation();

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/client/index.tsx
@@ -1,0 +1,36 @@
+import { Plugin } from '@nocobase/client';
+import { useDesignable, useField, useFieldSchema } from '@nocobase/client';
+import { useTranslation } from 'react-i18next';
+
+export class PluginFieldKeepValueClient extends Plugin {
+  async load() {
+    this.schemaSettingsManager.addItem('fieldSettings:FormItem.decoratorOptions', 'keepValueAfterSubmit', {
+      type: 'switch',
+      useComponentProps() {
+        const { t } = useTranslation();
+        const { dn } = useDesignable();
+        const field = useField();
+        const fieldSchema = useFieldSchema();
+        return {
+          title: t('Preserve value after submission'),
+          checked: fieldSchema['x-component-props']?.retainValue ?? false,
+          onChange(checked: boolean) {
+            fieldSchema['x-component-props'] = fieldSchema['x-component-props'] || {};
+            fieldSchema['x-component-props'].retainValue = checked;
+            field.componentProps = field.componentProps || {};
+            field.componentProps.retainValue = checked;
+            dn.emit('patch', {
+              schema: {
+                'x-uid': fieldSchema['x-uid'],
+                'x-component-props': fieldSchema['x-component-props'],
+              },
+            });
+            dn.refresh();
+          },
+        };
+      },
+    });
+  }
+}
+
+export default PluginFieldKeepValueClient;

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/index.ts
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/index.ts
@@ -1,0 +1,2 @@
+export * from './server';
+export { default } from './server';

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/locale/en-US.json
@@ -1,0 +1,3 @@
+{
+  "Preserve value after submission": "Preserve value after submission"
+}

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/locale/zh-CN.json
@@ -1,0 +1,3 @@
+{
+  "Preserve value after submission": "提交后保留原值"
+}

--- a/packages/plugins/@nocobase/plugin-field-keep-value/src/server/index.ts
+++ b/packages/plugins/@nocobase/plugin-field-keep-value/src/server/index.ts
@@ -1,0 +1,3 @@
+import { Plugin } from '@nocobase/server';
+
+export default class PluginFieldKeepValueServer extends Plugin {}


### PR DESCRIPTION
## Summary
- add PluginFieldKeepValue to allow keeping form field values after submit
- update form reset helper to respect `retainValue` option

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6877c94d5b208327ae49f817ed312ac9